### PR TITLE
HP-2605: expression `date('c', $timestamp) will throw error `Deprecat…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ hidev-local.yml
 .idea
 .project
 .settings
+.phpunit.result.cache
 Thumbs.db
 nbproject
 

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,14 @@
         "yiisoft/yii2": "^2.0"
     },
     "require-dev": {
-        "hiqdev/hidev-php": "<2.0",
-        "hiqdev/hidev-hiqdev": "<2.0"
+        "yiisoft/yii2": "*@dev",
+        "hiqdev/hidev": "dev-master",
+        "hiqdev/hidev-php": "dev-master",
+        "hiqdev/hidev-hiqdev": "dev-master",
+        "phpunit/phpunit": "^9.5",
+        "nikic/php-parser": "^4.12",
+        "laminas/laminas-code": "^4.5",
+        "opis/closure": "3.x-dev as 3.6.x-dev"
     },
     "suggest": {
         "sentry/sdk": "Sentry ^3.3.0 for error reporting"
@@ -54,6 +60,11 @@
     "autoload": {
         "psr-4": {
             "hiqdev\\yii2\\monitoring\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "hiqdev\\yii2\\monitoring\\tests\\": "tests"
         }
     },
     "extra": {
@@ -68,5 +79,11 @@
             "type": "composer",
             "url": "https://asset-packagist.org"
         }
-    ]
+    ],
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true,
+            "yiisoft/composer-config-plugin": true
+        }
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/_bootstrap.php">
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false"
+         bootstrap="./tests/_bootstrap.php">
     <testsuites>
         <testsuite name="Unit Test Suite">
             <directory>./tests/unit/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -1,15 +1,20 @@
 <?php
-/**
- * Health monitoring for Yii2 applications
- *
- * @link      https://github.com/hiqdev/yii2-monitoring
- * @package   yii2-monitoring
- * @license   BSD-3-Clause
- * @copyright Copyright (c) 2017, HiQDev (http://hiqdev.com/)
- */
 
-error_reporting(E_ALL & ~E_NOTICE);
+use Yiisoft\Composer\Config\Builder;
 
-$bootstrap = __DIR__ . '/../src/_bootstrap.php';
+define('APP_TYPE', 'tests');
 
-require_once file_exists($bootstrap) ? $bootstrap : __DIR__ . '/../vendor/autoload.php';
+error_reporting(E_ALL);
+date_default_timezone_set('UTC');
+
+$config = require Builder::path('web');
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../../../yiisoft/yii2/Yii.php';
+
+$path = dirname(__DIR__);
+$config['id'] = 'test-app';
+$config['basePath'] = $path;
+
+\Yii::setAlias('@root', $path);
+\Yii::$app = new \yii\web\Application($config);

--- a/tests/unit/ModuleTest.php
+++ b/tests/unit/ModuleTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace hiqdev\yii2\monitoring\tests\unit;
+
+use hiqdev\yii2\monitoring\Module;
+use yii\base\ErrorException;
+use yii\log\Logger;
+
+class ModuleTest extends TestCase
+{
+    private Module $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $module = $this->getMockBuilder(Module::class)
+            ->setConstructorArgs(['monitoring'])
+            ->onlyMethods(['getDebugUrl'])
+            ->getMock();
+        $module->method('getDebugUrl')->willReturn('test-url');
+        $this->module = $module;
+    }
+
+    /**
+     * Tests specifically that no ErrorException is thrown when using a float timestamp
+     *
+     * @return void
+     */
+    public function testPrepareMessageDataDoesNotThrowErrorOnFloatTimestamp(): void
+    {
+        try {
+            $message = $this->createMessageWith(1627484400.123456);
+            $this->module->prepareMessageData($message);
+            $this->assertTrue(true); // If we get here, no exception was thrown
+        } catch (ErrorException $e) {
+            $this->fail('ErrorException was thrown: ' . $e->getMessage());
+        }
+    }
+
+    private function createMessageWith(int|float $timestamp): array
+    {
+        $traces = [
+            ['file' => '/path/to/file.php', 'line' => 123],
+            ['file' => '/path/to/another.php', 'line' => 456],
+        ];
+
+        return [
+            'Test message',
+            Logger::LEVEL_ERROR,
+            'application',
+            $timestamp,
+            $traces,
+            'throwable' => null,
+            'debugUrl' => 'test-url',
+        ];
+    }
+}

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace hiqdev\yii2\monitoring\tests\unit;
+
+use hiqdev\yii\compat\yii;
+use Psr\Container\ContainerInterface;
+use yii\di\Container;
+
+abstract class TestCase extends \PHPUnit\Framework\TestCase
+{
+    public function di(): Container|ContainerInterface
+    {
+        return yii::getContainer();
+    }
+}


### PR DESCRIPTION
…ed: Implicit conversion from float 1753098843.870129 to int loses precision`. Refactor `Module::prepareMessageData`, enhance compatibility, add tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved timestamp formatting with microsecond precision in log messages.
  * Added comprehensive unit tests for enhanced reliability.
  * Introduced a base test case class for easier dependency injection in tests.

* **Chores**
  * Updated development dependencies and configuration for improved compatibility and testing.
  * Enhanced test bootstrap to fully initialize the Yii application in the test environment.
  * Expanded `.gitignore` to exclude PHPUnit result cache files.

* **Refactor**
  * Minor syntax and formatting updates for better code consistency.

* **Documentation**
  * Reformatted PHPUnit configuration for clarity and removed deprecated settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->