### PR TITLE
HP-2610: fix fatal error in project with incompatible with above php8.0 syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: Run PHP Tests
 
 on:
   push:
-    branches: [ main, master ]
   pull_request:
+  schedule:
+    - cron: "0 9 * * 1"
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,10 @@ jobs:
     name: PHP ${{ matrix.php }} Test
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Set up PHP
+      - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Run PHP Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: [7.4, 8.0, 8.1, 8.2, 8.3]
+
+    name: PHP ${{ matrix.php }} Test
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Validate composer.json
+        run: composer validate
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,9 @@
         "allow-plugins": {
             "yiisoft/yii2-composer": true,
             "yiisoft/composer-config-plugin": true
+        },
+        "platform": {
+            "php": "7.4.33"
         }
     }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -171,7 +171,7 @@ class Module extends \yii\base\Module
         }
     }
 
-    private function formatTimestamp(int|float $timestamp): string
+    private function formatTimestamp($timestamp): string
     {
         if (is_int($timestamp)) {
             return date('c', $timestamp);

--- a/tests/unit/ModuleTest.php
+++ b/tests/unit/ModuleTest.php
@@ -39,7 +39,7 @@ class ModuleTest extends TestCase
         }
     }
 
-    private function createMessageWith(int|float $timestamp): array
+    private function createMessageWith($timestamp): array
     {
         $traces = [
             ['file' => '/path/to/file.php', 'line' => 123],

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace hiqdev\yii2\monitoring\tests\unit;
 
 use hiqdev\yii\compat\yii;
-use Psr\Container\ContainerInterface;
 use yii\di\Container;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    public function di(): Container|ContainerInterface
+    public function di(): Container
     {
         return yii::getContainer();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced automated PHP test workflow for continuous integration across multiple PHP versions.
  * Updated configuration to specify PHP 7.4.33 as the platform version.

* **Refactor**
  * Removed explicit type declarations from certain method parameters to allow more flexible input types.
  * Simplified a method's return type in test utilities for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->